### PR TITLE
add nova prefilter for blazar

### DIFF
--- a/nova/conf/scheduler.py
+++ b/nova/conf/scheduler.py
@@ -147,6 +147,14 @@ Related options:
 
 - ``[scheduler] placement_aggregate_required_for_tenants``
 """),
+    cfg.BoolOpt("use_blazar_reservation_prefilter",
+        default=False,
+        help="Whether to apply blazar reservation filter during nova prefilter stage"
+    ),
+    cfg.BoolOpt("blazar_reservation_required",
+        default=False,
+        help="If true, a reservation hunt must be present on all requests"
+    ),
     cfg.BoolOpt("query_placement_for_availability_zone",
         default=True,
         deprecated_for_removal=True,

--- a/nova/scheduler/request_filter.py
+++ b/nova/scheduler/request_filter.py
@@ -150,49 +150,64 @@ def blazar_reservation_filter(ctxt, request_spec):
     """
 
     # skip the filter if not enabled
-    enabled = CONF['blazar:physical:host'].use_blazar_reservation_prefilter
+    enabled = CONF.scheduler.use_blazar_reservation_prefilter
     if not enabled:
         return False
 
-    LOG.debug(f"entered blazar prefilter with request_spec {request_spec}")
-
     # allow setting reservation hint as mandatory
-    reservation_required = CONF['blazar:physical:host'].blazar_reservation_required
+    reservation_required = CONF.scheduler.blazar_reservation_required
+    reservation_hints = request_spec.scheduler_hints.get('reservation', None)
 
-    reservation_hints = request_spec.scheduler_hints.get('reservation',None)
+    # handle missing reservation hint
+    if not reservation_hints:
+        no_reservation_hint_msg = f"Can't schedule instance {request_spec.instance_uuid}. No reservation hint was specified."
+        if reservation_required:
+            LOG.warning(no_reservation_hint_msg)
+            raise exception.RequestFilterFailed(reason=_(no_reservation_hint_msg))
+        else:
+            LOG.info(no_reservation_hint_msg)
+            # if no reservation hint, we'll skip the rest of this prefilter
+            return False
 
-    if reservation_required and not reservation_hints:
-        LOG.warning('Request did not specify mandatory reservation hint')
-        raise exception.RequestFilterFailed(
-            reason=_('Request did not specify mandatory reservation hint'))
+    # after this point, assume we have a reservation hint. we don't check for
+    # "reservation required" any longer. At this point, you requested a reservation,
+    # and none matched, so 0 is the expected result. If you didn't want one,
+    # you shouldn't have asked for one!
 
-    # get list of aggregates owned by the requesting project
+
+    # handle possibility of multiple reservation hints, or malformed requests by
+    # not asking DB directly for the name, instead get list that project "could" use.
     aggregates_for_project_id = objects.AggregateList.get_by_metadata(ctxt,
                                                                       key='blazar:owner',
                                                                       value=request_spec.project_id)
 
+    if not aggregates_for_project_id:
+        no_project_aggregates_msg=f"Can't schedule instance {request_spec.instance_uuid}. Tenant {request_spec.project_id} has no available aggregates"
+        LOG.warning(no_project_aggregates_msg)
+        raise exception.RequestFilterFailed(reason=_(no_project_aggregates_msg))
+
+    # of the aggregates owned by the project, check for ones with the right name
     aggregate_uuids_for_reservation = set([])
     for agg in aggregates_for_project_id:
         if agg.name in reservation_hints:
             aggregate_uuids_for_reservation.add(agg.uuid)
             break
 
+    # handle common case, we've found an aggregate to use, ask placement to filter by it
     if aggregate_uuids_for_reservation:
-        if ('requested_destination' not in request_spec or
-                request_spec.requested_destination is None):
+        if ('requested_destination' not in request_spec or request_spec.requested_destination is None):
             request_spec.requested_destination = objects.Destination()
         destination = request_spec.requested_destination
         destination.require_aggregates(aggregate_uuids_for_reservation)
-        LOG.debug('blazar_reservation_filter request filter added '
-                  'aggregates %s for tenant %r',
-                  ','.join(aggregate_uuids_for_reservation),
-                  request_spec.project_id)
-    elif reservation_required:
-        LOG.warning('Tenant %(tenant)s has no available aggregates',
-                    {'tenant': request_spec.project_id})
-        raise exception.RequestFilterFailed(
-            reason=_('No hosts available for tenant'))
+        LOG.debug('blazar_reservation_filter request filter added aggregates %s for tenant %r',
+                  ','.join(aggregate_uuids_for_reservation), request_spec.project_id)
+    else:
+        # no aggregates match
+        no_aggregates_for_reservation_hint_msg=f"Can't schedule instance {request_spec.instance_uuid}. No aggregates were found matching hints {reservation_hints}"
+        LOG.warning(no_aggregates_for_reservation_hint_msg)
+        raise exception.RequestFilterFailed(reason=_(no_aggregates_for_reservation_hint_msg))
 
+    # at this point, we've either raised an exception or successfully updated the destination aggregate
     return True
 
 

--- a/nova/scheduler/request_filter.py
+++ b/nova/scheduler/request_filter.py
@@ -30,7 +30,6 @@ CONF = nova.conf.CONF
 LOG = logging.getLogger(__name__)
 TENANT_METADATA_KEY = 'filter_tenant_id'
 
-
 def trace_request_filter(fn):
     @functools.wraps(fn)
     def wrapper(ctxt, request_spec):
@@ -127,6 +126,68 @@ def require_tenant_aggregate(ctxt, request_spec):
                   ','.join(aggregate_uuids_for_tenant),
                   request_spec.project_id)
     elif agg_required:
+        LOG.warning('Tenant %(tenant)s has no available aggregates',
+                    {'tenant': request_spec.project_id})
+        raise exception.RequestFilterFailed(
+            reason=_('No hosts available for tenant'))
+
+    return True
+
+@trace_request_filter
+def blazar_reservation_filter(ctxt, request_spec):
+    """Require hosts to be in an aggregate corresponding to a blazar reservation.
+    The reservation_id must be passed in as a scheduler hint, with key `reservation`
+
+    Additionally, the user must have permission to use the corresponding reservation.
+    For now, this is enforced by checking that the value 'blazar:owner' on the aggregate
+    matches the requesting project_id.
+
+    if reservation_required is set to true, any scheduling requests without a reservation
+    hint will be rejected.
+
+    In terms of behavior, this is just a combination of the map_az_to_placement_aggregate
+    and require_tenant_aggregate filters, with different key names.
+    """
+
+    # skip the filter if not enabled
+    enabled = CONF['blazar:physical:host'].use_blazar_reservation_prefilter
+    if not enabled:
+        return False
+
+    LOG.debug(f"entered blazar prefilter with request_spec {request_spec}")
+
+    # allow setting reservation hint as mandatory
+    reservation_required = CONF['blazar:physical:host'].blazar_reservation_required
+
+    reservation_hints = request_spec.scheduler_hints.get('reservation',None)
+
+    if reservation_required and not reservation_hints:
+        LOG.warning('Request did not specify mandatory reservation hint')
+        raise exception.RequestFilterFailed(
+            reason=_('Request did not specify mandatory reservation hint'))
+
+    # get list of aggregates owned by the requesting project
+    aggregates_for_project_id = objects.AggregateList.get_by_metadata(ctxt,
+                                                                      key='blazar:owner',
+                                                                      value=request_spec.project_id)
+
+    aggregate_uuids_for_reservation = set([])
+    for agg in aggregates_for_project_id:
+        if agg.name in reservation_hints:
+            aggregate_uuids_for_reservation.add(agg.uuid)
+            break
+
+    if aggregate_uuids_for_reservation:
+        if ('requested_destination' not in request_spec or
+                request_spec.requested_destination is None):
+            request_spec.requested_destination = objects.Destination()
+        destination = request_spec.requested_destination
+        destination.require_aggregates(aggregate_uuids_for_reservation)
+        LOG.debug('blazar_reservation_filter request filter added '
+                  'aggregates %s for tenant %r',
+                  ','.join(aggregate_uuids_for_reservation),
+                  request_spec.project_id)
+    elif reservation_required:
         LOG.warning('Tenant %(tenant)s has no available aggregates',
                     {'tenant': request_spec.project_id})
         raise exception.RequestFilterFailed(
@@ -370,6 +431,7 @@ ALL_REQUEST_FILTERS = [
     map_az_to_placement_aggregate,
     require_image_type_support,
     compute_status_filter,
+    blazar_reservation_filter,
     isolate_aggregates,
     transform_image_metadata,
     accelerators_filter,


### PR DESCRIPTION
We've been having issues with the blazar filter seing stale "host_state", and acting on incorrect info about aggregate membership. Our use of host_state is nearly worst-case, since we use only a single ironic-conductor, the host_state contains information about every single node.

Most of blazar's behavior could be implemented by taking advantage of the existing Nova prefilters, which read from the DB directly rather than parsing the host_state. This filtering takes place prior to making the request to placement, which besides not being subject to stale data, should significantly decrease the request sizes between nova and placement.

What we need the filters to do is listed below, along with ways we could adapt blazar to perform them with no code changes in nova.

## Restrict instance launches to specified reservation

leverage `map_az_to_placement_aggregate` prefilter

in nova-scheduler.conf, set `query_placement_for_availability_zone=True`
in launch request, pass `availability_zone` instead of `reservation` hint.

## Ensure tenants own the requested reservation

leverage `require_tenant_aggregate` prefilter

in nova-scheduler.conf, set: `require_tenant_aggregate=True`
when blazar creates and aggregate, set `filter_tenant_id` = project_id

## Prevent instance launches without a reservation

leverage `isolate_aggregates` prefilter

in nova-scheduler.conf, set `scheduler.enable_isolated_aggregate_filtering=True`

On freepool, set `trait:launch_without_reservation=required`

Alternately, this PR attaches a composite "blazar filter" which merely implements the above, using the logic from the mentioned filters.

This adds the following two config items for nova's "[scheduler]" section

```
blazar_reservation_required = True # whether the prefilter should deny all requests with no reservation hint
use_blazar_reservation_prefilter = True # whether to enable this prefilter
```