### PR TITLE
add a lock to prevent invalid aggregates cache

### DIFF
--- a/nova/scheduler/host_manager.py
+++ b/nova/scheduler/host_manager.py
@@ -379,15 +379,25 @@ class HostManager(object):
             self._update_aggregate(aggregates)
 
     def _update_aggregate(self, aggregate):
-        self.aggs_by_id[aggregate.id] = aggregate
-        for host in aggregate.hosts:
-            self.host_aggregates_map[host].add(aggregate.id)
-        # Refreshing the mapping dict to remove all hosts that are no longer
-        # part of the aggregate
-        for host in self.host_aggregates_map:
-            if (aggregate.id in self.host_aggregates_map[host] and
-                    host not in aggregate.hosts):
-                self.host_aggregates_map[host].remove(aggregate.id)
+        # add a lock to ensure nova scheduler has a consistent view of hosts per aggregate if they are
+        # added or removed in parallel. Lock per aggregate to reduce contention
+        # if multiple aggregates are modified at the same time.
+        _lock_name=f"nova-agg-{aggregate.name}"
+        @utils.synchronized(_lock_name)
+        def _locked_update_aggregate(aggregate):
+            self.aggs_by_id[aggregate.id] = aggregate
+            LOG.debug(f"host_manager cache for aggregate: {aggregate.name} has {aggregate.hosts}")
+
+            for host in aggregate.hosts:
+                self.host_aggregates_map[host].add(aggregate.id)
+            # Refreshing the mapping dict to remove all hosts that are no longer
+            # part of the aggregate
+            for host in self.host_aggregates_map:
+                if (aggregate.id in self.host_aggregates_map[host] and
+                        host not in aggregate.hosts):
+                    self.host_aggregates_map[host].remove(aggregate.id)
+
+        return _locked_update_aggregate(aggregate)
 
     def delete_aggregate(self, aggregate):
         """Deletes internal HostManager information about a specific aggregate.


### PR DESCRIPTION
this PR should fix the issue where the nova filters see incorrect information about host aggregates.
The issue is also mentioned in this older bug: https://bugs.launchpad.net/nova/+bug/1542491

The issue can be reproduced by adding multiple hosts (e.g. 5) to an aggregate in  parallel.

Debug logging for the contents of `aggregate.hosts` inside the update method shows that when executed in parallel, a race condition causes entries to overwrite each other, leaving usually only 1 or 2 hosts in the aggregate.

example when adding 4 hosts in parallel:
```
['adfbd886-0f55-488f-bb06-7dc7ddbf4937']
['adfbd886-0f55-488f-bb06-7dc7ddbf4937', 'f6732c5f-2b38-4f9e-b59d-fca67ea3a027']
['adfbd886-0f55-488f-bb06-7dc7ddbf4937', '45b5f9c9-203d-4bc1-a9d9-45a31f5c39a5']
['adfbd886-0f55-488f-bb06-7dc7ddbf4937', '162c8701-c331-4528-9681-d256c8423a1c']
```
 