### PR TITLE
Fix/get ci runnable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Unit tests
+
+on: [push, pull_request]
+
+jobs:
+  unittest:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - "3.9"
+        - "3.10"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - run: tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-minversion = 3.18.0
+minversion = 4.4.0
 envlist = py3,functional,pep8
 
 [testenv]
+constrain_package_deps = true # constrain transitive dependencies too
 usedevelop = True
 allowlist_externals =
   bash
@@ -10,7 +11,6 @@ allowlist_externals =
   rm
   env
   make
-install_command = python -I -m pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.1} {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US
@@ -22,7 +22,9 @@ setenv =
 # TODO(stephenfin): Remove once we bump our upper-constraint to SQLAlchemy 2.0
   SQLALCHEMY_WARN_20=1
 deps =
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2023.1}
   -r{toxinidir}/test-requirements.txt
+  setuptools<82.0.0
 extras =
   zvm
   hyperv


### PR DESCRIPTION
Handle issues with old versions of setuptools and other deps by modifying tox, and add a github workflow to run the unittests.

Some existing failures are present on our fork.