### PR TITLE
Revert duplicated _build_resources cleanup from 7dbfcc3

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -2851,16 +2851,13 @@ class ComputeManager(manager.Manager):
             self._build_resources_cleanup(instance, network_info)
             raise exception.BuildAbortException(instance_uuid=instance.uuid,
                     reason=e.format_message())
-        except Exception as e:
+        except Exception:
             LOG.exception('Failure prepping block device',
                           instance=instance)
-            # Make sure the async call finishes
-            if network_info is not None:
-                network_info.wait(do_raise=False)
-                self.driver.clean_networks_preparation(instance, network_info)
-            self.driver.failed_spawn_cleanup(instance)
             self._build_resources_cleanup(instance, network_info)
-            raise exception.BuildAbortException('Failure prepping block device. ' + str(e))
+            msg = _('Failure prepping block device.')
+            raise exception.BuildAbortException(instance_uuid=instance.uuid,
+                    reason=msg)
 
         resources['accel_info'] = list(spec_arqs.values())
         try:


### PR DESCRIPTION
Commit 7dbfcc3255 ("make error message more informative") rewrote the
_build_resources block-device-prep failure handler. It inlined the
network_info.wait(), clean_networks_preparation() and
failed_spawn_cleanup() calls that _build_resources_cleanup() already
makes, while leaving the helper call in place, so each cleanup ran
twice. It also changed the raise to a positional BuildAbortException,
dropping the structured instance_uuid/reason fields.

Revert that hunk to the upstream form so each cleanup runs once. Fixes:

  test_build_resources_reraises_on_failed_bdm_prep
  test_build_resources_exception_before_yield

The only remaining delta from 7dbfcc3 in this file is the
last_seen_error_message reschedule argument, handled in a separate
commit.

Fixes: 7dbfcc3255 ("make error message more informative")
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
