### PR TITLE
Align unit tests with last_seen_error_message from 7dbfcc3

### DIFF
--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -7145,7 +7145,8 @@ class ComputeManagerBuildInstanceTestCase(test.NoDBTestCase):
                 [self.instance], self.image, self.filter_properties,
                 self.admin_pass, self.injected_files, self.requested_networks,
                 self.security_groups, self.block_device_mapping,
-                request_spec={}, host_lists=[fake_host_list])
+                request_spec={}, host_lists=[fake_host_list],
+                last_seen_error_message='')
         mock_failed.assert_called_once_with(self.node)
 
     @mock.patch.object(manager.ComputeManager, '_shutdown_instance')
@@ -7232,7 +7233,8 @@ class ComputeManagerBuildInstanceTestCase(test.NoDBTestCase):
             [instance], self.image, self.filter_properties,
             self.admin_pass, self.injected_files, self.requested_networks,
             self.security_groups, self.block_device_mapping,
-            request_spec={}, host_lists=[fake_host_list])
+            request_spec={}, host_lists=[fake_host_list],
+            last_seen_error_message='')
 
     @mock.patch.object(manager.ComputeManager, '_build_and_run_instance')
     @mock.patch.object(manager.ComputeManager, '_cleanup_allocated_networks')
@@ -7279,7 +7281,8 @@ class ComputeManagerBuildInstanceTestCase(test.NoDBTestCase):
             [instance], self.image, self.filter_properties,
             self.admin_pass, self.injected_files, self.requested_networks,
             self.security_groups, self.block_device_mapping,
-            request_spec={}, host_lists=[fake_host_list])
+            request_spec={}, host_lists=[fake_host_list],
+            last_seen_error_message='')
 
     @mock.patch.object(manager.ComputeManager, '_build_and_run_instance')
     @mock.patch.object(conductor_api.ComputeTaskAPI, 'build_instances')
@@ -7334,7 +7337,8 @@ class ComputeManagerBuildInstanceTestCase(test.NoDBTestCase):
             [instance], self.image, self.filter_properties,
             self.admin_pass, self.injected_files, self.requested_networks,
             self.security_groups, self.block_device_mapping,
-            request_spec={}, host_lists=[fake_host_list])
+            request_spec={}, host_lists=[fake_host_list],
+            last_seen_error_message='')
 
     @mock.patch.object(objects.InstanceActionEvent,
                        'event_finish_with_failure')
@@ -7443,7 +7447,8 @@ class ComputeManagerBuildInstanceTestCase(test.NoDBTestCase):
                 [self.instance], self.image, self.filter_properties,
                 self.admin_pass, self.injected_files, self.requested_networks,
                 self.security_groups, self.block_device_mapping,
-                request_spec={}, host_lists=[fake_host_list])
+                request_spec={}, host_lists=[fake_host_list],
+                last_seen_error_message='')
 
     @mock.patch.object(objects.InstanceActionEvent,
                        'event_finish_with_failure')
@@ -7498,7 +7503,8 @@ class ComputeManagerBuildInstanceTestCase(test.NoDBTestCase):
                 [self.instance], self.image, self.filter_properties,
                 self.admin_pass, self.injected_files, self.requested_networks,
                 self.security_groups, self.block_device_mapping,
-                request_spec={}, host_lists=[fake_host_list])
+                request_spec={}, host_lists=[fake_host_list],
+                last_seen_error_message='')
 
     @mock.patch('nova.compute.resource_tracker.ResourceTracker.instance_claim',
                 new=mock.MagicMock())
@@ -7564,7 +7570,9 @@ class ComputeManagerBuildInstanceTestCase(test.NoDBTestCase):
                 [self.instance], self.image, self.filter_properties,
                 self.admin_pass, self.injected_files, self.requested_networks,
                 self.security_groups, self.block_device_mapping,
-                request_spec={}, host_lists=[fake_host_list])
+                request_spec={}, host_lists=[fake_host_list],
+                last_seen_error_message=(
+                    'Affinity instance group policy was violated'))
 
     @mock.patch('nova.compute.resource_tracker.ResourceTracker.instance_claim',
                 new=mock.MagicMock())
@@ -8044,7 +8052,10 @@ class ComputeManagerBuildInstanceTestCase(test.NoDBTestCase):
                 self.image, self.filter_properties, self.admin_pass,
                 self.injected_files, self.requested_networks,
                 self.security_groups, self.block_device_mapping,
-                request_spec={}, host_lists=[fake_host_list])
+                request_spec={}, host_lists=[fake_host_list],
+                last_seen_error_message=(
+                    'Insufficient compute resources: '
+                    'resource unavailable.'))
         mock_nil.assert_called_once_with(self.instance)
 
     @mock.patch.object(manager.ComputeManager, '_build_resources')

--- a/nova/tests/unit/conductor/test_conductor.py
+++ b/nova/tests/unit/conductor/test_conductor.py
@@ -4722,7 +4722,8 @@ class ConductorTaskRPCAPITestCase(_BaseTaskTestCase,
                   'injected_files': mock.sentinel.injected_files,
                   'requested_networks': mock.sentinel.requested_networks,
                   'security_groups': mock.sentinel.security_groups,
-                  'request_spec': mock.sentinel.request_spec}
+                  'request_spec': mock.sentinel.request_spec,
+                  'last_seen_error_message': None}
             cctxt_mock.cast.assert_called_once_with(
                 self.context, 'build_instances', **kw)
         _test()
@@ -4752,7 +4753,8 @@ class ConductorTaskRPCAPITestCase(_BaseTaskTestCase,
                   'admin_password': mock.sentinel.admin_password,
                   'injected_files': mock.sentinel.injected_files,
                   'requested_networks': mock.sentinel.requested_networks,
-                  'security_groups': mock.sentinel.security_groups}
+                  'security_groups': mock.sentinel.security_groups,
+                  'last_seen_error_message': None}
             cctxt_mock.cast.assert_called_once_with(
                 self.context, 'build_instances', **kw)
         _test()


### PR DESCRIPTION
Commit 7dbfcc3255 ("make error message more informative") threads a new
last_seen_error_message kwarg from the compute-manager reschedule path
through the conductor build_instances RPC so MaxRetriesExceeded reports
the underlying failure. The upstream unit tests assert the exact
build_instances call and RPC cast arguments, so the added kwarg broke
eight reschedule tests in test_compute_mgr and two cast tests in
test_conductor.

Update those assertions to expect last_seen_error_message. The kwarg is
left always-on; gating it behind a conductor RPC version bump is deferred
to the 2024.1 forward-port (single-version deploys are unaffected).

Fixes: 7dbfcc3255 ("make error message more informative")
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
