### PR TITLE
Filter hypervisor servers by node name, not search pattern

### DIFF
--- a/nova/api/openstack/compute/hypervisors.py
+++ b/nova/api/openstack/compute/hypervisors.py
@@ -486,7 +486,9 @@ class HypervisorsController(wsgi.Controller):
             try:
                 instances = self.host_api.instance_get_all_by_host(context,
                     compute_node.host)
-                instances = [ i for i in instances if i.node == id ]
+                instances = [
+                    i for i in instances
+                    if i.node == compute_node.hypervisor_hostname]
             except exception.HostMappingNotFound as e:
                 raise webob.exc.HTTPNotFound(explanation=e.format_message())
 

--- a/nova/tests/unit/api/openstack/compute/test_hypervisors.py
+++ b/nova/tests/unit/api/openstack/compute/test_hypervisors.py
@@ -106,10 +106,14 @@ TEST_HYPERS_OBJ = [objects.ComputeNode(**hyper_dct)
 TEST_HYPERS[0].update({'service': TEST_SERVICES[0]})
 TEST_HYPERS[1].update({'service': TEST_SERVICES[1]})
 
-TEST_SERVERS = [dict(name="inst1", uuid=uuids.instance_1, host="compute1"),
-                dict(name="inst2", uuid=uuids.instance_2, host="compute2"),
-                dict(name="inst3", uuid=uuids.instance_3, host="compute1"),
-                dict(name="inst4", uuid=uuids.instance_4, host="compute2")]
+TEST_SERVERS = [dict(name="inst1", uuid=uuids.instance_1, host="compute1",
+                     node="hyper1"),
+                dict(name="inst2", uuid=uuids.instance_2, host="compute2",
+                     node="hyper2"),
+                dict(name="inst3", uuid=uuids.instance_3, host="compute1",
+                     node="hyper1"),
+                dict(name="inst4", uuid=uuids.instance_4, host="compute2",
+                     node="hyper2")]
 
 
 def fake_compute_node_get_all(context, limit=None, marker=None):


### PR DESCRIPTION
Commit ace962e3f3 ("Fix hypervisors.search") filtered the per-hypervisor
server list with "i.node == id", but id is the route's hostname search
pattern (e.g. "hyper"), not a node name, so the comparison never matched
and every server was dropped. test_servers failed for all four
microversions (V21/V228/V233/V252) with KeyError: 'servers'.

Compare against compute_node.hypervisor_hostname, which is what the
filter intended, and give the test fixtures matching node values. Also
fixes the E201/E202 whitespace in the comprehension.

Note: the 2.53+ with_servers paths still lack this filter; tracked for
the forward-port.

Fixes: ace962e3f3 ("Fix hypervisors.search")
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
