### PR TITLE
Keep ComputeNodeList identical to upstream; fall back in caller

### DIFF
--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -6720,8 +6720,10 @@ class AggregateAPI:
         # support for this now, but Blazar will still place hosts in Nova aggregates;
         # once Blazar is adapted to, e.g., integrate against Placement directly,
         # we can revert this, and the other Nova patches, like get_by_host_or_node_name.
-        nodes = objects.ComputeNodeList.get_all_by_host(
-            context, host_name, try_node_name=True)
+        try:
+            nodes = objects.ComputeNodeList.get_all_by_host(context, host_name)
+        except exception.ComputeHostNotFound:
+            nodes = [objects.ComputeNode.get_by_nodename(context, host_name)]
         node_name = nodes[0].hypervisor_hostname
         try:
             self.placement_client.aggregate_add_host(
@@ -6781,8 +6783,10 @@ class AggregateAPI:
         # support for this now, but Blazar will still place hosts in Nova aggregates;
         # once Blazar is adapted to, e.g., integrate against Placement directly,
         # we can revert this, and the other Nova patches, like get_by_host_or_node_name.
-        nodes = objects.ComputeNodeList.get_all_by_host(
-            context, host_name, try_node_name=True)
+        try:
+            nodes = objects.ComputeNodeList.get_all_by_host(context, host_name)
+        except exception.ComputeHostNotFound:
+            nodes = [objects.ComputeNode.get_by_nodename(context, host_name)]
         node_name = nodes[0].hypervisor_hostname
         try:
             # Anything else this raises is handled in the route handler as

--- a/nova/objects/compute_node.py
+++ b/nova/objects/compute_node.py
@@ -481,16 +481,11 @@ class ComputeNodeList(base.ObjectListBase, base.NovaObject):
         return db.compute_node_get_all_by_host(context, host)
 
     @base.remotable_classmethod
-    def get_all_by_host(cls, context, host, use_slave=False, try_node_name=False):
-        try:
-            db_computes = cls._db_compute_node_get_all_by_host(
-                context, host, use_slave=use_slave)
-            return base.obj_make_list(context, cls(context), objects.ComputeNode,
-                                      db_computes)
-        except exception.ComputeHostNotFound:
-            if try_node_name:
-                return [objects.ComputeNode.get_by_nodename(context, host)]
-            raise
+    def get_all_by_host(cls, context, host, use_slave=False):
+        db_computes = cls._db_compute_node_get_all_by_host(context, host,
+                                                      use_slave=use_slave)
+        return base.obj_make_list(context, cls(context), objects.ComputeNode,
+                                  db_computes)
 
     @staticmethod
     @db.select_db_reader_mode


### PR DESCRIPTION
Commit c3417925a3 ("Try to look up hosts by hypervisor in agg ops")
added a try_node_name kwarg to the remotable
ComputeNodeList.get_all_by_host, which changed the object fingerprint
without bumping its VERSION and broke TestObjectVersions.test_versions
and TestNotificationObjectVersions.test_versions.

Bumping the object version would fork nova's object-version namespace and
force a hash reconciliation on every forward-port. Instead, revert
get_all_by_host to the upstream signature and move the bare-metal
fallback (look the compute node up by hypervisor_hostname when
ComputeHostNotFound is raised) into the two AggregateAPI callers in
compute/api.py. ComputeNodeList is now byte-identical to upstream, so
test_versions passes with no hash-table edits.

Fixes: c3417925a3 ("Try to look up hosts by hypervisor in agg ops")
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
