### PR TITLE
Feat/last seen error message

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -2471,7 +2471,7 @@ class ComputeManager(manager.Manager):
                     image, filter_properties, admin_password,
                     injected_files, requested_networks, security_groups,
                     block_device_mapping, request_spec=request_spec,
-                    host_lists=[host_list], last_seen_error_message=e.kwargs['reason'])
+                    host_lists=[host_list])
 
             if isinstance(e, exception.RescheduledByPolicyException):
                 return build_results.RESCHEDULED_BY_POLICY
@@ -2851,16 +2851,13 @@ class ComputeManager(manager.Manager):
             self._build_resources_cleanup(instance, network_info)
             raise exception.BuildAbortException(instance_uuid=instance.uuid,
                     reason=e.format_message())
-        except Exception as e:
+        except Exception:
             LOG.exception('Failure prepping block device',
                           instance=instance)
-            # Make sure the async call finishes
-            if network_info is not None:
-                network_info.wait(do_raise=False)
-                self.driver.clean_networks_preparation(instance, network_info)
-            self.driver.failed_spawn_cleanup(instance)
             self._build_resources_cleanup(instance, network_info)
-            raise exception.BuildAbortException('Failure prepping block device. ' + str(e))
+            msg = _('Failure prepping block device.')
+            raise exception.BuildAbortException(instance_uuid=instance.uuid,
+                    reason=msg)
 
         resources['accel_info'] = list(spec_arqs.values())
         try:

--- a/nova/conductor/api.py
+++ b/nova/conductor/api.py
@@ -115,7 +115,7 @@ class ComputeTaskAPI(object):
     def build_instances(self, context, instances, image, filter_properties,
             admin_password, injected_files, requested_networks,
             security_groups, block_device_mapping, legacy_bdm=True,
-            request_spec=None, host_lists=None, last_seen_error_message=None):
+            request_spec=None, host_lists=None):
         self.conductor_compute_rpcapi.build_instances(context,
                 instances=instances, image=image,
                 filter_properties=filter_properties,
@@ -124,7 +124,7 @@ class ComputeTaskAPI(object):
                 security_groups=security_groups,
                 block_device_mapping=block_device_mapping,
                 legacy_bdm=legacy_bdm, request_spec=request_spec,
-                host_lists=host_lists, last_seen_error_message=last_seen_error_message)
+                host_lists=host_lists)
 
     def schedule_and_build_instances(self, context, build_requests,
                                      request_spec, image,

--- a/nova/conductor/manager.py
+++ b/nova/conductor/manager.py
@@ -681,6 +681,7 @@ class ComputeTaskManager:
         # lists may be empty if there are no more hosts left in a rescheduling
         # situation.
         is_reschedule = host_lists is not None
+        last_exc_reason = filter_properties.get('retry', {}).get('exc_reason')
         try:
             # check retry policy. Rather ugly use of instances[0]...
             # but if we've exceeded max retries... then we really only
@@ -702,6 +703,9 @@ class ComputeTaskManager:
                     msg = ("Exhausted all hosts available for retrying build "
                            "failures for instance %(instance_uuid)s." %
                            {"instance_uuid": instances[0].uuid})
+                    if last_exc_reason:
+                        msg += _(" Last exception: %(exc_reason)s") % {
+                            "exc_reason": last_exc_reason}
                     raise exception.MaxRetriesExceeded(reason=msg)
             else:
                 # This is not a reschedule, so we need to call the scheduler to
@@ -791,6 +795,9 @@ class ComputeTaskManager:
                     msg = ("Exhausted all hosts available for retrying build "
                            "failures for instance %(instance_uuid)s." %
                            {"instance_uuid": instance.uuid})
+                    if last_exc_reason:
+                        msg += _(" Last exception: %(exc_reason)s") % {
+                            "exc_reason": last_exc_reason}
                     exc = exception.MaxRetriesExceeded(reason=msg)
                     self._cleanup_when_reschedule_fails(
                         context, instance, exc, legacy_request_spec,

--- a/nova/conductor/manager.py
+++ b/nova/conductor/manager.py
@@ -642,7 +642,7 @@ class ComputeTaskManager:
     def build_instances(self, context, instances, image, filter_properties,
             admin_password, injected_files, requested_networks,
             security_groups, block_device_mapping=None, legacy_bdm=True,
-            request_spec=None, host_lists=None, last_seen_error_message=None):
+            request_spec=None, host_lists=None):
         # TODO(ndipanov): Remove block_device_mapping and legacy_bdm in version
         #                 2.0 of the RPC API.
         # TODO(danms): Remove this in version 2.0 of the RPC API
@@ -702,8 +702,6 @@ class ComputeTaskManager:
                     msg = ("Exhausted all hosts available for retrying build "
                            "failures for instance %(instance_uuid)s." %
                            {"instance_uuid": instances[0].uuid})
-                    if last_seen_error_message:
-                        msg = last_seen_error_message
                     raise exception.MaxRetriesExceeded(reason=msg)
             else:
                 # This is not a reschedule, so we need to call the scheduler to

--- a/nova/conductor/rpcapi.py
+++ b/nova/conductor/rpcapi.py
@@ -354,7 +354,7 @@ class ComputeTaskAPI(object):
     def build_instances(self, context, instances, image, filter_properties,
             admin_password, injected_files, requested_networks,
             security_groups, block_device_mapping, legacy_bdm=True,
-            request_spec=None, host_lists=None, last_seen_error_message=None):
+            request_spec=None, host_lists=None):
         image_p = jsonutils.to_primitive(image)
         kwargs = {"instances": instances, "image": image_p,
                   "filter_properties": filter_properties,
@@ -363,8 +363,7 @@ class ComputeTaskAPI(object):
                   "requested_networks": requested_networks,
                   "security_groups": security_groups,
                   "request_spec": request_spec,
-                  "host_lists": host_lists,
-                  "last_seen_error_message": last_seen_error_message}
+                  "host_lists": host_lists}
         version = '1.19'
         if not self.client.can_send_version(version):
             version = '1.18'

--- a/nova/scheduler/manager.py
+++ b/nova/scheduler/manager.py
@@ -495,7 +495,7 @@ class SchedulerManager(manager.Manager):
             'There are %(hosts)d hosts available but '
             '%(required_count)d instances requested to build.',
             {'hosts': len(hosts), 'required_count': required_count})
-        reason = _('There are not enough hosts available.')
+        reason = _('There are not enough hosts available.  To troubleshoot, please see https://bit.ly/chi-faq-launch-fail')
         raise exception.NoValidHost(reason=reason)
 
     def _cleanup_allocations(self, context, instance_uuids):

--- a/nova/scheduler/manager.py
+++ b/nova/scheduler/manager.py
@@ -495,7 +495,7 @@ class SchedulerManager(manager.Manager):
             'There are %(hosts)d hosts available but '
             '%(required_count)d instances requested to build.',
             {'hosts': len(hosts), 'required_count': required_count})
-        reason = _('There are not enough hosts available. To troubleshoot, please see bit.ly/faq-instance-failure')
+        reason = _('There are not enough hosts available.')
         raise exception.NoValidHost(reason=reason)
 
     def _cleanup_allocations(self, context, instance_uuids):

--- a/nova/tests/unit/conductor/test_conductor.py
+++ b/nova/tests/unit/conductor/test_conductor.py
@@ -831,10 +831,16 @@ class _BaseTaskTestCase(object):
         # build_instances() is a cast, we need to wait for it to complete
         self.useFixture(fixtures.CastAsCallFixture(self))
 
+        filter_properties = {}
+        # default set by populate_retry
+        filter_properties["retry"] = {"num_attempts": 0, "hosts": []}
+        # inject exc reason
+        filter_properties["retry"]["exc_reason"] = "fake_exc_reason"
+
         self.conductor.build_instances(
             context=self.context,
             instances=[instance], image=image,
-            filter_properties={},
+            filter_properties=filter_properties,
             admin_password='admin_password',
             injected_files='injected_files',
             requested_networks=None,
@@ -850,6 +856,56 @@ class _BaseTaskTestCase(object):
             self.context, 'build_instances',
             instance.uuid, test.MatchType(dict), 'error',
             test.MatchType(exc.MaxRetriesExceeded))
+
+        # exception is 5th positional arg in notify_about_compute_task_error
+        raised = mock_notify.call_args[0][5]
+        self.assertIn('Exhausted all hosts', str(raised))
+        self.assertIn('Last exception: fake_exc_reason', str(raised))
+
+    @mock.patch.object(conductor_manager.ComputeTaskManager,
+            '_destroy_build_request')
+    @mock.patch('nova.compute.utils.notify_about_compute_task_error')
+    @mock.patch.object(objects.Instance, 'save')
+    def test_build_instances_empty_host_list(self, _mock_save, mock_notify,
+                _mock_destroy):
+        # A list of three alternate hosts for one instance
+        instance = fake_instance.fake_instance_obj(
+            self.context, expected_attrs='system_metadata')
+        image = {'fake-data': 'should_pass_silently'}
+
+        # build_instances() is a cast, we need to wait for it to complete
+        self.useFixture(fixtures.CastAsCallFixture(self))
+
+        filter_properties = {}
+        # default set by populate_retry
+        filter_properties["retry"] = {"num_attempts": 0, "hosts": []}
+        # inject exc reason
+        filter_properties["retry"]["exc_reason"] = "fake_exc_reason"
+
+        self.conductor.build_instances(
+            context=self.context,
+            instances=[instance], image=image,
+            filter_properties=filter_properties,
+            admin_password='admin_password',
+            injected_files='injected_files',
+            requested_networks=None,
+            security_groups='security_groups',
+            block_device_mapping=None,
+            legacy_bdm=None,
+            host_lists=[[]]
+        )
+
+        # Since claim_resources() is mocked to always return False, we will run
+        # out of alternate hosts, and complain about MaxRetriesExceeded.
+        mock_notify.assert_called_once_with(
+            self.context, 'build_instances',
+            instance.uuid, test.MatchType(dict), 'error',
+            test.MatchType(exc.MaxRetriesExceeded))
+
+        # exception is positional arg 5 in notify_about_compute_task_error
+        raised = mock_notify.call_args[0][5]
+        self.assertIn('Exhausted all hosts', str(raised))
+        self.assertIn('Last exception: fake_exc_reason', str(raised))
 
     @mock.patch.object(conductor_manager.ComputeTaskManager,
             '_destroy_build_request')


### PR DESCRIPTION
Commit https://github.com/ChameleonCloud/nova/commit/7dbfcc3255808cffdcad1c9003650ff82b492f56 plumbed extra failure info through Nova' RPC mechanism, as well as added a bit.ly url linking to the Chameleon FAQ on the "not enough hosts" error.

Because this commit modified the RPC signature without a corresponding update to rpc version/registry, it caused nova unit tests to fail.

As it turns out the nova conductor already had the information available locally, this PR reverts the old commit and replaces it with a simpler mechanism.

As side-effect, it reverts a change to nova compute-manager that resulted from a bad rebase, an removes the bit.ly URL as it has a broken link anyway.